### PR TITLE
Fix AVC file

### DIFF
--- a/Distribution/GameData/Endurance/Endurance.version
+++ b/Distribution/GameData/Endurance/Endurance.version
@@ -3,7 +3,7 @@
 "URL":"http://ksp-avc.cybutek.net/version.php?id=258",
 "DOWNLOAD":"http://spacedock.info/mod/357/Endurance%20%28from%20Interstellar%29%20Continued...",
 "VERSION":{"MAJOR":1,"MINOR":6,"PATCH":0,"BUILD":0},
-"KSP_VERSION":{"MAJOR":1,"MINOR":3,"PATCH":1,
-"KSP_VERSION_MIN":{"MAJOR":1,"MINOR":3,"PATCH":1,
-"KSP_VERSION_MAX":{"MAJOR":1,"MINOR":3,"PATCH":1
+"KSP_VERSION":{"MAJOR":1,"MINOR":3,"PATCH":1},
+"KSP_VERSION_MIN":{"MAJOR":1,"MINOR":3,"PATCH":1},
+"KSP_VERSION_MAX":{"MAJOR":1,"MINOR":3,"PATCH":1}
 }


### PR DESCRIPTION
The closing braces for the KSP_VERSION* objects were lost in the latest update.